### PR TITLE
specify comment.char for read.table

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -75,7 +75,7 @@ enrichr <- function(genes, databases = NULL) {
                  query=list(file="API", backgroundType=x))
         r <- gsub("&#39;", "'", intToUtf8(r$content))
         tc <- textConnection(r)
-        r <- read.table(tc, sep = "\t", header = TRUE, quote = "")
+        r <- read.table(tc, sep = "\t", header = TRUE, quote = "", comment.char="")
         close(tc)
         cat("Done.\n")
         return(r)


### PR DESCRIPTION
This is to deal with encoding issues, e.g. avoid error in read.table when a row has entry like "TCR signaling in na&#xef;ve CD8+ T cells"